### PR TITLE
Update Administrate version constraint in gemspec

### DIFF
--- a/administrate-field-lat_lng.gemspec
+++ b/administrate-field-lat_lng.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'administrate', '~> 0.2.1'
+  spec.add_dependency 'administrate', '>= 0.2.1', '<= 0.3.0'
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Thanks for a nice gem! Here is a small PR to add support for the latest Administrate version.