### PR TITLE
Support Administrate < 0.6.0

### DIFF
--- a/administrate-field-lat_lng.gemspec
+++ b/administrate-field-lat_lng.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'administrate', '>= 0.2.1', '< 0.5'
+  spec.add_dependency 'administrate', '>= 0.2.1', '< 0.6'
   spec.add_dependency 'leaflet-rails', '~> 1.0'
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
Hi! Administrate `0.5.0` got [released recently](https://github.com/thoughtbot/administrate/releases/tag/v0.5.0). This adds support for that. Have tried it out, and it is working fine.