### PR TITLE
Support Administrate 0.6

### DIFF
--- a/administrate-field-lat_lng.gemspec
+++ b/administrate-field-lat_lng.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'administrate', '>= 0.2.1', '< 0.6'
+  spec.add_dependency 'administrate', '>= 0.2.1', '< 0.7'
   spec.add_dependency 'leaflet-rails', '~> 1.0'
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
Hi,

It's me again. :) Administrate 0.6 is out, and here is a PR to support that in the dependency version constraints.

Thanks