### PR TITLE
allow administrate 0.16

### DIFF
--- a/administrate-field-lat_lng.gemspec
+++ b/administrate-field-lat_lng.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'administrate', '>= 0.3', '< 0.16'
+  spec.add_dependency 'administrate', '>= 0.3', '< 0.17'
   spec.add_dependency 'leaflet-rails', '~> 1.0'
 
   spec.add_development_dependency "bundler", "~> 1.11"


### PR DESCRIPTION
Administrate 0.16 fixes an issue with strings passed to routes: CVE-2021-22885

https://kmitov.com/posts/rails-please-use-symbols-for-polymorphic-route-arguments/

It may be good to update this gem, so it does not hold people back from upgrading administrate.
The lat-lng picker works well for me with 0.16.