### PR TITLE
bump administrate version (0.17)

### DIFF
--- a/administrate-field-lat_lng.gemspec
+++ b/administrate-field-lat_lng.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "administrate-field-lat_lng"
-  spec.version       = "1.15.0"
+  spec.version       = "1.16.0"
   spec.authors       = ["Quinn Daley"]
   spec.email         = ["quinn@fishpercolator.co.uk"]
 

--- a/administrate-field-lat_lng.gemspec
+++ b/administrate-field-lat_lng.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'administrate', '>= 0.3', '< 0.17'
+  spec.add_dependency 'administrate', '>= 0.3', '< 0.18'
   spec.add_dependency 'leaflet-rails', '~> 1.0'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
-  spec.add_development_dependency "pry" 
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "erubis"
 end


### PR DESCRIPTION
Hi 👋 

First off, thanks for maintaining this repo. Has been very useful to us @toshitech

We wanted to use the latest version of Administrate(0.17) and this gem was a blocker. I have ran the tests and also I used my forked version on our app with the latest Administrate and all seems good. I think bumping the gemspec might be safe?

Thanks again

Chris Hopkins

