### PR TITLE
Support Administrate 0.19

### DIFF
--- a/administrate-field-lat_lng.gemspec
+++ b/administrate-field-lat_lng.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'administrate', '>= 0.3', '< 0.18'
+  spec.add_dependency 'administrate', '>= 0.3', '< 0.19'
   spec.add_dependency 'leaflet-rails', '~> 1.0'
 
   spec.add_development_dependency "bundler"

--- a/administrate-field-lat_lng.gemspec
+++ b/administrate-field-lat_lng.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'administrate', '>= 0.3', '< 0.19'
+  spec.add_dependency 'administrate', '>= 0.3', '< 0.20'
   spec.add_dependency 'leaflet-rails', '~> 1.0'
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Dear maintainer,

Administrate released it's 0.19 version 2 weeks ago. I've been running a few tests from my fork and all seems to be working perfectly.

Bumping the gemspec might be safe

Thanks